### PR TITLE
Added a safety check by using window.StickySidebar

### DIFF
--- a/config/jsdoc/template/scripts/app.js
+++ b/config/jsdoc/template/scripts/app.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // configure the sticky sidebar
-if (window.innerWidth > 1023 && StickySidebar) {
+if (window.innerWidth > 1023 && window.StickySidebar) {
     var sidebar = new StickySidebar('#sidebar-nav', {
         innerWrapperSelector: '.sidebar__inner',
         topSpacing: 20,

--- a/docs/scripts/app.js
+++ b/docs/scripts/app.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // configure the sticky sidebar
-if (window.innerWidth > 1023 && StickySidebar) {
+if (window.innerWidth > 1023 && window.StickySidebar) {
     var sidebar = new StickySidebar('#sidebar-nav', {
         innerWrapperSelector: '.sidebar__inner',
         topSpacing: 20,


### PR DESCRIPTION
Instead of referencing `StickySidebar` to check for availability we now do `window.StickySidebar` which is safe and will not throw an uncaught exception when the reference is `undefined`. 