### PR TITLE
Fixed mobile meta tag for docs

### DIFF
--- a/config/jsdoc/template/tmpl/layout.tmpl
+++ b/config/jsdoc/template/tmpl/layout.tmpl
@@ -13,7 +13,8 @@ if(env.conf.templates && env.conf.templates.betterDocs) {
 <head>
     <meta charset="utf-8">
     <title>ol-kit | <?js= title ?></title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/BasemapManager.html
+++ b/docs/BasemapManager.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | BasemapManager</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/Basemaps_BasemapManager.js.html
+++ b/docs/Basemaps_BasemapManager.js.html
@@ -5,7 +5,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | Basemaps/BasemapManager.js</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/Basemaps_BingMaps.js.html
+++ b/docs/Basemaps_BingMaps.js.html
@@ -5,7 +5,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | Basemaps/BingMaps.js</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/Basemaps_BlankWhite.js.html
+++ b/docs/Basemaps_BlankWhite.js.html
@@ -5,7 +5,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | Basemaps/BlankWhite.js</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/Basemaps_OpenStreetMap.js.html
+++ b/docs/Basemaps_OpenStreetMap.js.html
@@ -5,7 +5,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | Basemaps/OpenStreetMap.js</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/Basemaps_StamenTerrain.js.html
+++ b/docs/Basemaps_StamenTerrain.js.html
@@ -5,7 +5,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | Basemaps/StamenTerrain.js</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/Basemaps_StamenTonerDark.js.html
+++ b/docs/Basemaps_StamenTonerDark.js.html
@@ -5,7 +5,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | Basemaps/StamenTonerDark.js</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/Basemaps_StamenTonerLite.js.html
+++ b/docs/Basemaps_StamenTonerLite.js.html
@@ -5,7 +5,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | Basemaps/StamenTonerLite.js</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/BingMaps.html
+++ b/docs/BingMaps.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | BingMaps</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/BlankWhite.html
+++ b/docs/BlankWhite.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | BlankWhite</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/Compass.html
+++ b/docs/Compass.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | Compass</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/Controls.html
+++ b/docs/Controls.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | Controls</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/Controls_Compass.js.html
+++ b/docs/Controls_Compass.js.html
@@ -5,7 +5,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | Controls/Compass.js</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/Controls_Controls.js.html
+++ b/docs/Controls_Controls.js.html
@@ -5,7 +5,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | Controls/Controls.js</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/Controls_ZoomControls.js.html
+++ b/docs/Controls_ZoomControls.js.html
@@ -5,7 +5,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | Controls/ZoomControls.js</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/Map.html
+++ b/docs/Map.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | Map</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/Map_Map.js.html
+++ b/docs/Map_Map.js.html
@@ -5,7 +5,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | Map/Map.js</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/Map_utils.js.html
+++ b/docs/Map_utils.js.html
@@ -5,7 +5,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | Map/utils.js</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/OpenStreetMap.html
+++ b/docs/OpenStreetMap.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | OpenStreetMap</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/StamenTerrain.html
+++ b/docs/StamenTerrain.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | StamenTerrain</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/StamenTonerDark.html
+++ b/docs/StamenTonerDark.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | StamenTonerDark</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/StamenTonerLite.html
+++ b/docs/StamenTonerLite.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | StamenTonerLite</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/ZoomControls.html
+++ b/docs/ZoomControls.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | ZoomControls</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | Docs</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/global.html
+++ b/docs/global.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | Global</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
     
     <meta charset="utf-8">
     <title>ol-kit | Docs</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
 
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>

--- a/docs/tutorial-Getting Started.html
+++ b/docs/tutorial-Getting Started.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | Getting Started</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/tutorial-connectToMap.html
+++ b/docs/tutorial-connectToMap.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | connectToMap</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/docs/tutorial-i18n Support.html
+++ b/docs/tutorial-i18n Support.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>ol-kit | i18n Support</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
+
 
     <!-- these scripts must be at the top to properly syntax highlight code examples -->
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>

--- a/src-docs/overrides/index.html
+++ b/src-docs/overrides/index.html
@@ -5,7 +5,7 @@
     
     <meta charset="utf-8">
     <title>ol-kit | Docs</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densityDpi=device-dpi" />
 
     <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>


### PR DESCRIPTION
Trying a more comprehensive meta tag solution. Verified this works on Chrome in mobile device view:

<img width="833" alt="Screen Shot 2020-04-03 at 10 33 51 AM" src="https://user-images.githubusercontent.com/1056932/78378492-a3b03600-7596-11ea-8d4e-cd4f46e0a589.png">
