### PR TITLE
build the docs with latest popup changes

### DIFF
--- a/docs/PopupActionGroup.html
+++ b/docs/PopupActionGroup.html
@@ -233,13 +233,13 @@
     
         
 
-<div id='t559m2jbnnrk933nzkf'></div>
+<div id='e20r2d45exvk935d3a0'></div>
 
 <script>
   ReactDOM.render(ReactWrapper({
     example: "./example.md",
-    uniqId: "t559m2jbnnrk933nzkf",
-  }), document.getElementById('t559m2jbnnrk933nzkf'));
+    uniqId: "e20r2d45exvk935d3a0",
+  }), document.getElementById('e20r2d45exvk935d3a0'));
 </script>
     
 

--- a/docs/PopupActionItem.html
+++ b/docs/PopupActionItem.html
@@ -266,13 +266,13 @@
     
         
 
-<div id='dpsicc9xs18k933nzki'></div>
+<div id='01wdwf55e9r8k935d3a3'></div>
 
 <script>
   ReactDOM.render(ReactWrapper({
     example: "./example.md",
-    uniqId: "dpsicc9xs18k933nzki",
-  }), document.getElementById('dpsicc9xs18k933nzki'));
+    uniqId: "01wdwf55e9r8k935d3a3",
+  }), document.getElementById('01wdwf55e9r8k935d3a3'));
 </script>
     
 

--- a/docs/PopupDataList.html
+++ b/docs/PopupDataList.html
@@ -222,13 +222,13 @@
     
         
 
-<div id='a1es2eho5vtk933nzkr'></div>
+<div id='9qwicse4sqk935d3ac'></div>
 
 <script>
   ReactDOM.render(ReactWrapper({
     example: "./example.md",
-    uniqId: "a1es2eho5vtk933nzkr",
-  }), document.getElementById('a1es2eho5vtk933nzkr'));
+    uniqId: "9qwicse4sqk935d3ac",
+  }), document.getElementById('9qwicse4sqk935d3ac'));
 </script>
     
 

--- a/docs/PopupDefaultPage.html
+++ b/docs/PopupDefaultPage.html
@@ -354,13 +354,13 @@
     
         
 
-<div id='zj27lzt012k933nzkz'></div>
+<div id='599qxraz9sk935d3al'></div>
 
 <script>
   ReactDOM.render(ReactWrapper({
     example: "./example.md",
-    uniqId: "zj27lzt012k933nzkz",
-  }), document.getElementById('zj27lzt012k933nzkz'));
+    uniqId: "599qxraz9sk935d3al",
+  }), document.getElementById('599qxraz9sk935d3al'));
 </script>
     
 

--- a/docs/PopupPageLayout.html
+++ b/docs/PopupPageLayout.html
@@ -255,13 +255,13 @@
     
         
 
-<div id='vuxrdq5yy6jk933nzla'></div>
+<div id='7zpjtmjpy1yk935d3au'></div>
 
 <script>
   ReactDOM.render(ReactWrapper({
     example: "./example.md",
-    uniqId: "vuxrdq5yy6jk933nzla",
-  }), document.getElementById('vuxrdq5yy6jk933nzla'));
+    uniqId: "7zpjtmjpy1yk935d3au",
+  }), document.getElementById('7zpjtmjpy1yk935d3au'));
 </script>
     
 

--- a/docs/PopupPageLayoutChild.html
+++ b/docs/PopupPageLayoutChild.html
@@ -266,13 +266,13 @@
     
         
 
-<div id='a42uusfmkolk933nzlc'></div>
+<div id='cu0069p82k935d3ax'></div>
 
 <script>
   ReactDOM.render(ReactWrapper({
     example: "./example.md",
-    uniqId: "a42uusfmkolk933nzlc",
-  }), document.getElementById('a42uusfmkolk933nzlc'));
+    uniqId: "cu0069p82k935d3ax",
+  }), document.getElementById('cu0069p82k935d3ax'));
 </script>
     
 

--- a/docs/PopupTabs.html
+++ b/docs/PopupTabs.html
@@ -244,13 +244,13 @@
     
         
 
-<div id='s47vgrrj1sk933nzlf'></div>
+<div id='oabgz7sbyyk935d3b0'></div>
 
 <script>
   ReactDOM.render(ReactWrapper({
     example: "./example.md",
-    uniqId: "s47vgrrj1sk933nzlf",
-  }), document.getElementById('s47vgrrj1sk933nzlf'));
+    uniqId: "oabgz7sbyyk935d3b0",
+  }), document.getElementById('oabgz7sbyyk935d3b0'));
 </script>
     
 

--- a/docs/tutorial-Popup_.html
+++ b/docs/tutorial-Popup_.html
@@ -81,7 +81,7 @@
     <h1>Popup</h1>
 <p>Popups are great for contextual content, interaction and controls that live relative to the map. A popup can be implemented on your ol-kit <code>&lt;Map&gt;</code> with a single-line drop-in.</p>
 <h2>Prebuilt, Ready to Go</h2>
-<p>Since components exported from ol-kit already have a reference to the map (see <a href="../docs/tutorial-connectToMap.html">connectToMap</a>), you can a slick popup experience out of the box. When a feature or features are clicked, the popup snaps to the edge of the features(s) bounding and also repositions itself on drag to an area that it fits based on the edge of the viewport and other components on the map. This all works without requiring a single prop!</p>
+<p>Since components exported from ol-kit already have a reference to the map (see <a href="./tutorial-connectToMap.html">connectToMap</a>), you can a slick popup experience out of the box. When a feature or features are clicked, the popup snaps to the edge of the features(s) bounding and also repositions itself on drag to an area that it fits based on the edge of the viewport and other components on the map. This all works without requiring a single prop!</p>
 <pre class="prettyprint source lang-javascript"><code>import React from 'react'
 import { Map, Popup } from '@bayer/ol-kit'
 
@@ -96,9 +96,9 @@ const App = () => {
 export default App
 </code></pre>
 <p>That will look something like this (minus the data layer):
-<img src="../config/jsdoc/template/static/popup-screenshot-1.png" alt="ol-kit logo"></p>
+<img src="./static/popup-screenshot-1.png" alt="popup screenshot"></p>
 <h2>Customize</h2>
-<p>What you're seeing is the default popup with a <a href="../docs/PopupDefaultInsert.html">PopupDefaultInsert</a> as its child. To pass different children to the popup or create custom functionality checkout the <a href="../docs/Popup.html">docs for popup</a>.</p>
+<p>What you're seeing is the default popup with a <a href="./PopupDefaultInsert.html">PopupDefaultInsert</a> as its child. To pass different children to the popup or create custom functionality checkout the <a href="./Popup.html">docs for popup</a>.</p>
 </article>
 
 </section>

--- a/src-docs/tutorials/Popup.md
+++ b/src-docs/tutorials/Popup.md
@@ -2,7 +2,7 @@
 Popups are great for contextual content, interaction and controls that live relative to the map. A popup can be implemented on your ol-kit `<Map>` with a single-line drop-in.
 
 ## Prebuilt, Ready to Go
-Since components exported from ol-kit already have a reference to the map (see [connectToMap](../docs/tutorial-connectToMap.html)), you can a slick popup experience out of the box. When a feature or features are clicked, the popup snaps to the edge of the features(s) bounding and also repositions itself on drag to an area that it fits based on the edge of the viewport and other components on the map. This all works without requiring a single prop!
+Since components exported from ol-kit already have a reference to the map (see [connectToMap](./tutorial-connectToMap.html)), you can a slick popup experience out of the box. When a feature or features are clicked, the popup snaps to the edge of the features(s) bounding and also repositions itself on drag to an area that it fits based on the edge of the viewport and other components on the map. This all works without requiring a single prop!
 ```javascript
 import React from 'react'
 import { Map, Popup } from '@bayer/ol-kit'
@@ -18,7 +18,7 @@ const App = () => {
 export default App
 ```
 That will look something like this (minus the data layer):
-![popup screenshot](../config/jsdoc/template/static/popup-screenshot-1.png)
+![popup screenshot](./static/popup-screenshot-1.png)
 
 ## Customize
-What you're seeing is the default popup with a [PopupDefaultInsert](../docs/PopupDefaultInsert.html) as its child. To pass different children to the popup or create custom functionality checkout the [docs for popup](../docs/Popup.html).
+What you're seeing is the default popup with a [PopupDefaultInsert](./PopupDefaultInsert.html) as its child. To pass different children to the popup or create custom functionality checkout the [docs for popup](./Popup.html).


### PR DESCRIPTION
i forgot to run `npm run docs` on my last changes before pushing 🤦  -- we need to add a hook or ideally separate doc builds from the PRs themselves so that the most recent code gets built into docs and persisted to the docsite.