### PR TITLE
add no-console errors to linter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
   "extends": ["eslint:recommended", "plugin:react/recommended", "standard"],
   "parser": "babel-eslint",
   "plugins": [
-    "react"
+    "react",
+    "react-hooks"
   ],
   "parserOptions": {
     "ecmaFeatures": {
@@ -62,6 +63,7 @@
     "no-alert": "error",
     "no-array-constructor": "error",
     "no-class-assign": "error",
+    "no-console": "error",
     "no-continue": "error",
     "no-duplicate-imports": "error",
     "no-eval": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11275,6 +11275,12 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.5.tgz",
+      "integrity": "sha512-3YLSjoArsE2rUwL8li4Yxx1SUg3DQWp+78N3bcJQGWVZckcp+yeQGsap/MSq05+thJk57o+Ww4PtZukXGL02TQ==",
+      "dev": true
+    },
     "eslint-plugin-standard": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "eslint-plugin-node": "~11.0.0",
     "eslint-plugin-promise": "~3.5.0",
     "eslint-plugin-react": "~7.19.0",
+    "eslint-plugin-react-hooks": "^4.0.5",
     "eslint-plugin-standard": "~4.0.1",
     "html-webpack-plugin": "~4.3.0",
     "husky": "~4.2.5",

--- a/src/DataLayers/utils.test.js
+++ b/src/DataLayers/utils.test.js
@@ -93,7 +93,7 @@ describe('loadDataLayer', () => {
     const parser = new DOMParser()
     const kmlData = parser.parseFromString(POLYGON_KML, 'text/xml')
 
-    console.log('kmlData', kmlData)
+    // console.log('kmlData', kmlData)
     // need to allow import of kml files via babel
     const dataLayer = await loadDataLayer(map, kmlData)
     const layers = map.getLayers().getArray()
@@ -104,7 +104,7 @@ describe('loadDataLayer', () => {
     // data layer should be added to map
     expect(layers[1]).toBe(dataLayer)
 
-    console.log('data:', dataLayer)
+    // console.log('data:', dataLayer)
   })
 
   it.skip('loadDataLayer should load valid kml endpoint', async () => {
@@ -119,7 +119,7 @@ describe('loadDataLayer', () => {
     const dataLayer = await loadDataLayer(map, 'https://data.nasa.gov/api/geospatial/7zbq-j77a?method=export&format=KML')
     const layers = map.getLayers().getArray()
 
-    console.log('features endpoint', dataLayer.getSource().getFeatures())
+    // console.log('features endpoint', dataLayer.getSource().getFeatures())
 
     expect(layers.length).toBe(2)
     // should return a VectorLayer

--- a/src/Popup/Popup.test.js
+++ b/src/Popup/Popup.test.js
@@ -48,7 +48,7 @@ describe('<Popup />', () => {
     const onMapInit = jest.fn(map => {
       testMap = map
     })
-    const onMapClick = jest.fn(e => console.log(e))
+    const onMapClick = jest.fn()
     const { getByTestId } = render(<Map onMapInit={onMapInit} fullScreen><Popup onMapClick={onMapClick} show /></Map>)
 
     // wait for async child render
@@ -62,8 +62,8 @@ describe('<Popup />', () => {
 
     const coords = [minx, maxy]
 
-    console.log('set', testMap.getTargetElement())
-    console.log('pixel', testMap.getCoordinateFromPixel([0, 0]), testMap.getSize(), testMap.getView().getCenter(), testMap.getView().calculateExtent([600, 400]))
+    // console.log('set', testMap.getTargetElement())
+    // console.log('pixel', testMap.getCoordinateFromPixel([0, 0]), testMap.getSize(), testMap.getView().getCenter(), testMap.getView().calculateExtent([600, 400]))
 
     // add a feature to that map at a known pixel location
     const features = [new olFeature(new olPoint([coords]))]


### PR DESCRIPTION
### Quick Description of Changes (+ screenshots for ui changes):
Linter is running on commit hooks- make sure you `npm i` to get the latest husky deps for the commit/push hooks...linter will now error on `console` statements 👍 