### PR TITLE
Add try/catch to async onMapInits

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,18 @@ class App extends React.Component {
     // nice to have map set on the window while debugging
     window.map = map
 
-    // find a geojson or kml dataset (url or file) to load on the map
-    const data = 'https://data.nasa.gov/api/geospatial/7zbq-j77a?method=export&format=KML'
-    const dataLayer = await loadDataLayer(map, data)
-    // set the title on the layer to show in LayerPanel
-    dataLayer.set('title', 'NASA Data')
+    // if data fails to load, components inside of mount will fail to render
+    try {
+      // find a geojson or kml dataset (url or file) to load on the map
+      const data = 'https://data.nasa.gov/api/geospatial/7zbq-j77a?method=export&format=KML'
+      const dataLayer = await loadDataLayer(map, data)
+      // set the title on the layer to show in LayerPanel
+      dataLayer.set('title', 'NASA Data')
 
-    console.log('data layer:', dataLayer)
+      console.log('data layer:', dataLayer)
+    } catch (err) {
+      console.error(err)
+    }
   }
 
   render () {

--- a/app/demos/space/App.js
+++ b/app/demos/space/App.js
@@ -27,13 +27,17 @@ function App (props) {
   const onMapInit = async (map) => {
     window.map = map
     
-    // Here we are fetching a KML layer and adding this layer to the map. This data maps out NASA's geopolitical boundries (countries)
-    const dataLayer = await loadDataLayer(map, 'https://data.nasa.gov/api/geospatial/7zbq-j77a?method=export&format=KML')
-    
-    dataLayer.getSource().getFeatures().forEach(f => f.set('title', f.get('name')))
-    dataLayer.set('title', 'NASA Geopolitcal Boundaries')
-    //setting to false by default, to view the layer the user must go to the layer panel and make it visible
-    dataLayer.set('visible', false)
+    try {
+      // Here we are fetching a KML layer and adding this layer to the map. This data maps out NASA's geopolitical boundries (countries)
+      const dataLayer = await loadDataLayer(map, 'https://data.nasa.gov/api/geospatial/7zbq-j77a?method=export&format=KML')
+
+      dataLayer.getSource().getFeatures().forEach(f => f.set('title', f.get('name')))
+      dataLayer.set('title', 'NASA Geopolitcal Boundaries')
+      //setting to false by default, to view the layer the user must go to the layer panel and make it visible
+      dataLayer.set('visible', false)
+    } catch (err) {
+      console.error(err)
+    }
   }
 
   return (

--- a/app/demos/world/App.js
+++ b/app/demos/world/App.js
@@ -38,10 +38,14 @@ class App extends React.Component {
     })
 
     map.addLayer(layer)
+    
+    try {
+      const dataLayer = await loadDataLayer(map, 'https://data.nasa.gov/api/geospatial/7zbq-j77a?method=export&format=KML')
 
-    const dataLayer = await loadDataLayer(map, 'https://data.nasa.gov/api/geospatial/7zbq-j77a?method=export&format=KML')
-
-    dataLayer.getSource().getFeatures().forEach(f => f.set('title', f.get('name')))
+      dataLayer.getSource().getFeatures().forEach(f => f.set('title', f.get('name')))
+    } catch (err) {
+      console.error(err)
+    }
 
     window.map = map
   }


### PR DESCRIPTION
Resolves: https://github.com/MonsantoCo/ol-kit/issues/201

### PR Safety Checklist:

 - [ ] Added the task to the appropriate release doc under **Enhancements** or **Bug Fixes**
 - [ ] Bump `package.json` & `package-lock.json` version numbers to appropriate release
 - [ ] (optional) All external API changes have been documented
 - [ ] (optional) Build docs: `npm run docs`

### Quick Description of Changes (+ screenshots for ui changes):

Basically, any async requests with the possibility to fail can prevent any other child components from rendering. This is a quick fix to get around this, although a more better solution can be proposed.
