### PR TITLE
add internal catch for errors in onMapInit block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bayer/ol-kit",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bayer/ol-kit",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "BSD",
   "description": "Mapping components & utils built with openlayers + react",
   "keywords": [

--- a/src/Draw/__snapshots__/DrawContainer.test.js.snap
+++ b/src/Draw/__snapshots__/DrawContainer.test.js.snap
@@ -18,7 +18,7 @@ exports[`<DrawContainer /> should render a basic prebuilt DrawContainer componen
         [33mclass[39m=[32m\\"sc-AxirZ flfhYH\\"[39m
         [33mhref[39m=[32m\\"https://ol-kit.com/\\"[39m
         [33mtarget[39m=[32m\\"_blank\\"[39m
-        [33mtitle[39m=[32m\\"Powered by ol-kit v1.0.1\\"[39m
+        [33mtitle[39m=[32m\\"Powered by ol-kit v1.0.2\\"[39m
       [36m>[39m
         [36m<svg[39m
           [33mviewBox[39m=[32m\\"0 0 204.76 236.44\\"[39m

--- a/src/Map/Map.js
+++ b/src/Map/Map.js
@@ -50,7 +50,9 @@ class Map extends React.Component {
 
       // update AFTER onMapInit to get map into the state/context
       isPromise
-        ? initCallback.then(() => this.setState({ mapInitialized: true }))
+        ? initCallback
+          .catch(e => ugh.error('Error caught in \'onMapInit\'', e))
+          .finally(() => this.setState({ mapInitialized: true })) // always initialize app
         : this.setState({ mapInitialized: true })
     }
 


### PR DESCRIPTION
Resolves: #201 

### PR Safety Checklist:

 - [ ] Added the task to the appropriate release doc under **Enhancements** or **Bug Fixes**
 - [x] Bump `package.json` & `package-lock.json` version numbers to appropriate release
 - [ ] (optional) All external API changes have been documented
 - [ ] (optional) Build docs: `npm run docs`

### Quick Description of Changes (+ screenshots for ui changes):
