### PR TITLE
Popup action item onClick should provide ol feature as prop

### DIFF
--- a/src/Popup/PopupInsert/PopupActionGroup/index.js
+++ b/src/Popup/PopupInsert/PopupActionGroup/index.js
@@ -23,8 +23,10 @@ class PopupActionGroup extends Component {
   }
 
   render () {
-    const { title, children } = this.props
+    const { title, children, feature } = this.props
     const { right, top } = this.el ? this.el.getBoundingClientRect() : { right: 0, top: 0 }
+    
+    const transformedChildren = React.Children.map(children, c => React.cloneElement(c, { feature }))
 
     return (
       <div style={{ position: 'relative' }} ref={(element) => { this.el = element }}>
@@ -44,7 +46,7 @@ class PopupActionGroup extends Component {
               showFlyout={this.state.showFlyout}
               onMouseEnter={() => this.onHover(true)}
               onMouseLeave={() => this.onHover(false)}>
-              {children}
+              {transformedChildren}
             </Flyout>,
             document.body)
         }
@@ -58,7 +60,10 @@ PopupActionGroup.propTypes = {
   children: PropTypes.node.isRequired,
 
   /** Title of the action group to display on the root level */
-  title: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
+  
+  /** Openlayers feature currently shown in popup */
+  feature: PropTypes.object
 }
 
 export default PopupActionGroup

--- a/src/Popup/PopupInsert/PopupActionItem/index.js
+++ b/src/Popup/PopupInsert/PopupActionItem/index.js
@@ -10,10 +10,10 @@ import { Item, Action } from './styled'
  */
 class PopupActionItem extends Component {
   render () {
-    const { children, title, disabled, onClick, style } = this.props
+    const { children, feature, title, disabled, onClick, style } = this.props
 
     return (
-      <Action role='button' onClick={disabled ? () => {} : onClick}>
+      <Action role='button' onClick={disabled ? () => {} : (e) => onClick(e, feature)}>
         {title ? <Item disabled={disabled} style={style}>{title}</Item> : children}
       </Action>
     )
@@ -34,7 +34,10 @@ PopupActionItem.propTypes = {
   onClick: PropTypes.func,
 
   /** Styles applied to <Item> */
-  style: PropTypes.object
+  style: PropTypes.object,
+  
+  /** OpenLayers feature on which the action is being done */
+  feature: PropTypes.object
 }
 
 PopupActionItem.defaultProps = {


### PR DESCRIPTION
Resolves: https://github.com/MonsantoCo/ol-kit/issues/255

### PR Safety Checklist:

 - [x] Added the task to the appropriate release doc under **Enhancements** or **Bug Fixes**
 - [ ] Bump `package.json` & `package-lock.json` version numbers to appropriate release
 - [ ] (optional) All external API changes have been documented
 - [ ] (optional) Build docs: `npm run docs`

### Quick Description of Changes (+ screenshots for ui changes):

I want my popup action item callbacks to have access to the feature.
