### PR TITLE
Context Menu Children fix

### DIFF
--- a/src/ContextMenu/ContextMenu.js
+++ b/src/ContextMenu/ContextMenu.js
@@ -109,7 +109,7 @@ class ContextMenu extends React.Component {
         <ContextMenuCoordinateGroup key={'coordgroup'} {...props} />
       ]
       // this logic allows defaults, custom or a mix (defaults render on top & custom below)
-      const contents = children ? [...(keepDefaults ? defaults : []), ...children] : defaults
+      const contents = children ? [...(keepDefaults ? defaults : []), ...React.Children.toArray(children)] : defaults
 
       return React.Children.map(contents, c => React.cloneElement(c, props))
     }


### PR DESCRIPTION
Resolves: https://github.com/MonsantoCo/ol-kit/issues/258

### PR Safety Checklist:

 - [x] Added the task to the appropriate release doc under **Enhancements** or **Bug Fixes**
 - [ ] Bump `package.json` & `package-lock.json` version numbers to appropriate release
 - [ ] (optional) All external API changes have been documented
 - [ ] (optional) Build docs: `npm run docs`

### Quick Description of Changes (+ screenshots for ui changes):

Can't spread `props.children` safely - React.Children.toArray makes it safe
