### PR TITLE
make the layer panel scrollable

### DIFF
--- a/src/LayerPanel/LayerPanelBase/styled.js
+++ b/src/LayerPanel/LayerPanelBase/styled.js
@@ -14,7 +14,8 @@ export const Card = styled(({ ...props }) => <MaterialCard {...props} />)({
   transition: 'all .3s',
   position: props => props.inline ? 'inline' : 'absolute',
   right: props => props.open ? '15px' : '-400px',
-  opacity: 0.9
+  opacity: 0.9,
+  overflow: 'scroll'
 })
 
 export const Tabs = styled(({ ...props }) => {


### PR DESCRIPTION
Resolves: https://github.com/MonsantoCo/ol-kit/issues/264

### PR Safety Checklist:

 - [x] Added the task to the appropriate release doc under **Enhancements** or **Bug Fixes**
 - [ ] Bump `package.json` & `package-lock.json` version numbers to appropriate release
 - [ ] (optional) All external API changes have been documented
 - [ ] (optional) Build docs: `npm run docs`

### Quick Description of Changes (+ screenshots for ui changes):

I changed the `overflow` property from a default of `hidden` to `scroll` on the layer panel base.
